### PR TITLE
[HTM-210] Fix null values for application crs's

### DIFF
--- a/src/main/docker/tomcat_conf/Catalina/localhost/admin.xml
+++ b/src/main/docker/tomcat_conf/Catalina/localhost/admin.xml
@@ -12,7 +12,9 @@
 
     <Parameter name="tailormap.i18n.languagecodes" override="false" value="nl_NL,en_US"/>
     <Parameter name="tailormap.projections.epsgcodes" override="false"
-               value="EPSG:28992[+proj=sterea +lat_0=52.15616055555555 +lon_0=5.38763888888889 +k=0.9999079 +x_0=155000 +y_0=463000 +ellps=bessel +towgs84=565.237,50.0087,465.658,-0.406857,0.350733,-1.87035,4.0812 +units=m +no_defs];EPSG:4326[]"/>
+               value="EPSG:28992[+proj=sterea +lat_0=52.15616055555555 +lon_0=5.38763888888889 +k=0.9999079 +x_0=155000 +y_0=463000 +ellps=bessel +towgs84=565.237,50.0087,465.658,-0.406857,0.350733,-1.87035,4.0812 +units=m +no_defs];EPSG:3857[+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext  +no_defs]"/>
+    <Parameter name="tailormap.projections.epsgnames" override="false"
+               value="EPSG:28992 (Amersfoort / RD New),EPSG:3857 (WGS 84 / Pseudo-Mercator)"/>
 
     <Parameter name="tailormap.solr.url" value="" override="false"/>
     <Parameter name="tailormap.solr.schedule" value="-1" override="false"/>

--- a/src/main/java/nl/tailormap/viewer/admin/stripes/ApplicationSettingsActionBean.java
+++ b/src/main/java/nl/tailormap/viewer/admin/stripes/ApplicationSettingsActionBean.java
@@ -37,6 +37,7 @@ import nl.tailormap.viewer.config.app.Level;
 import nl.tailormap.viewer.config.security.Group;
 import nl.tailormap.viewer.config.security.User;
 import nl.tailormap.viewer.config.services.BoundingBox;
+import nl.tailormap.viewer.config.services.CoordinateReferenceSystem;
 import nl.tailormap.viewer.helpers.app.ApplicationHelper;
 import nl.tailormap.viewer.util.SelectedContentCache;
 import org.apache.commons.lang3.StringUtils;
@@ -119,7 +120,7 @@ public class ApplicationSettingsActionBean extends ApplicationActionBean {
 
 
     @Validate
-    private List<String> groupsRead = new ArrayList<String>();
+    private List<String> groupsRead = new ArrayList<>();
 
     //<editor-fold defaultstate="collapsed" desc="getters & setters">
 
@@ -348,7 +349,6 @@ public class ApplicationSettingsActionBean extends ApplicationActionBean {
             application.setOwner(appOwner);
         }
         application.setStartExtent(startExtent);
-
         application.setMaxExtent(maxExtent);
 
         application.setAuthenticatedRequired(authenticatedRequired);
@@ -360,7 +360,6 @@ public class ApplicationSettingsActionBean extends ApplicationActionBean {
         application.authorizationsModified();
 
         application.setProjectionCode(projection);
-        Map<String, ClobElement> backupDetails = new HashMap();
         for (Map.Entry<String, ClobElement> e : application.getDetails().entrySet()) {
             if (Application.preventClearDetails.contains(e.getKey())) {
                 details.put(e.getKey(), e.getValue());
@@ -405,7 +404,7 @@ public class ApplicationSettingsActionBean extends ApplicationActionBean {
         }
 
         /*
-         * Check if owner is an excisting user
+         * Check if owner is an existing user.
          */
         if(owner != null){
             try {
@@ -421,11 +420,17 @@ public class ApplicationSettingsActionBean extends ApplicationActionBean {
             if(startExtent.getMinx() == null || startExtent.getMiny() == null || startExtent.getMaxx() == null || startExtent.getMaxy() == null ){
                 errors.add("startExtent", new SimpleError(getBundle().getString("viewer_admin.applicationsettingsbean.nostartext")));
             }
+            // force application CRS on startExtent
+            if (null == startExtent.getCrs())
+                startExtent.setCrs(new CoordinateReferenceSystem(projection.substring(0, projection.indexOf('['))));
         }
         if(maxExtent != null){
             if(maxExtent.getMinx() == null || maxExtent.getMiny() == null || maxExtent.getMaxx() == null || maxExtent.getMaxy() == null ){
                 errors.add("maxExtent", new SimpleError(getBundle().getString("viewer_admin.applicationsettingsbean.nomaxext")));
             }
+            // force application CRS on maxExtent
+            if (null == maxExtent.getCrs())
+                maxExtent.setCrs(new CoordinateReferenceSystem(projection.substring(0, projection.indexOf('['))));
         }
     }
 

--- a/src/main/webapp/META-INF/context.xml
+++ b/src/main/webapp/META-INF/context.xml
@@ -12,7 +12,9 @@ more about the available context attributes:
 
     <Parameter name="tailormap.i18n.languagecodes" override="false" value="nl_NL,en_US"/>
     <Parameter name="tailormap.projections.epsgcodes" override="false"
-               value="EPSG:28992[+proj=sterea +lat_0=52.15616055555555 +lon_0=5.38763888888889 +k=0.9999079 +x_0=155000 +y_0=463000 +ellps=bessel +towgs84=565.237,50.0087,465.658,-0.406857,0.350733,-1.87035,4.0812 +units=m +no_defs];EPSG:4326[]"/>
+               value="EPSG:28992[+proj=sterea +lat_0=52.15616055555555 +lon_0=5.38763888888889 +k=0.9999079 +x_0=155000 +y_0=463000 +ellps=bessel +towgs84=565.237,50.0087,465.658,-0.406857,0.350733,-1.87035,4.0812 +units=m +no_defs];EPSG:3857[+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext  +no_defs]"/>
+    <Parameter name="tailormap.projections.epsgnames" override="false"
+               value="EPSG:28992 (Amersfoort / RD New),EPSG:3857 (WGS 84 / Pseudo-Mercator)"/>
 
     <Parameter name="tailormap.solr.url" override="false" value=""/>
     <Parameter name="tailormap.solr.schedule" value="-1" override="false"/>

--- a/src/main/webapp/WEB-INF/jsp/application/applicationSettings.jsp
+++ b/src/main/webapp/WEB-INF/jsp/application/applicationSettings.jsp
@@ -110,7 +110,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                     <tr>
                                         <td>Projectie:</td>
                                         <td><stripes:select name="projection">
-                                                <stripes:option label="-- Kies een projectie --"/>
                                                 <stripes:options-collection collection="${actionBean.crses}" label="name" value="code"/>
                                             </stripes:select></td>
                                     </tr>
@@ -124,7 +123,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                 </td>
                             </tr>
                             <tr>
-                                <td>&nbsp;</td>
+                                <td><stripes:text name="startExtent.crs.name" readonly="true" disabled="disabled" size="9"/></td>
                                 <td>
                                     <fmt:message key="viewer_admin.applicationsettings.15" /> <stripes:text name="startExtent.maxx" maxlength="255" size="8"/>
                                     <fmt:message key="viewer_admin.applicationsettings.16" /> <stripes:text name="startExtent.maxy" maxlength="255" size="8"/>
@@ -138,11 +137,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                 </td>
                             </tr>
                             <tr>
-                                <td>&nbsp;</td>
+                                <td><stripes:text name="maxExtent.crs.name" readonly="true" disabled="disabled" size="9"/></td>
                                 <td>
                                     <fmt:message key="viewer_admin.applicationsettings.20" /> <stripes:text name="maxExtent.maxx" maxlength="255" size="8"/>
                                     <fmt:message key="viewer_admin.applicationsettings.21" /> <stripes:text name="maxExtent.maxy" maxlength="255" size="8"/>
                                 </td>
+
                             </tr>
                         </table>
                     </div>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -101,17 +101,17 @@
     </context-param>
     <context-param>
         <description>
-            List of projectioncodes, separated by semicolons.
+            List of projectioncodes, separated by semicolons. see eg. https://epsg.io/3857 or https://epsg.io/28992
         </description>
         <param-name>tailormap.projections.epsgcodes</param-name>
-        <param-value>EPSG:28992[+proj=sterea +lat_0=52.15616055555555 +lon_0=5.38763888888889 +k=0.9999079 +x_0=155000 +y_0=463000 +ellps=bessel +towgs84=565.237,50.0087,465.658,-0.406857,0.350733,-1.87035,4.0812 +units=m +no_defs]</param-value>
+        <param-value>EPSG:28992[+proj=sterea +lat_0=52.15616055555555 +lon_0=5.38763888888889 +k=0.9999079 +x_0=155000 +y_0=463000 +ellps=bessel +towgs84=565.237,50.0087,465.658,-0.406857,0.350733,-1.87035,4.0812 +units=m +no_defs];EPSG:3857[+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext  +no_defs]</param-value>
     </context-param>
     <context-param>
         <description>
             List of projection names(/labels), separated by comma's.
         </description>
         <param-name>tailormap.projections.epsgnames</param-name>
-        <param-value>RD</param-value>
+        <param-value>EPSG:28992 (Amersfoort / RD New),EPSG:3857 (WGS 84 / Pseudo-Mercator)</param-value>
     </context-param>
     <context-param>
         <description>minimum length of password</description>


### PR DESCRIPTION
- [x] add EPSG:3857 to tailormap.projections.epsgcodes, resolves HTM-277
- [x] prevent possible null values for `application.max_crs` and `application.start_crs` by forcing application application CRS on start and max extent

![image](https://user-images.githubusercontent.com/1165786/161250491-84971da4-9805-4fdc-afeb-3336e226ad5d.png)


resolves HTM-210