### PR TITLE
Configure hidpi options for WMS services and tiled layers

### DIFF
--- a/src/main/java/nl/tailormap/viewer/admin/stripes/GeoServiceActionBean.java
+++ b/src/main/java/nl/tailormap/viewer/admin/stripes/GeoServiceActionBean.java
@@ -162,6 +162,12 @@ public class GeoServiceActionBean extends LocalizableActionBean {
     private boolean skipDiscoverWFS = true;
     @Validate
     private String geofenceHeader;
+    @Validate
+    private String hiDpiMode;
+    @Validate
+    private boolean disableTiling = false;
+    @Validate
+    private Integer tilingGutter;
     
     private WaitPageStatus status;
     private JSONObject newService;
@@ -467,7 +473,31 @@ public class GeoServiceActionBean extends LocalizableActionBean {
         this.geofenceHeader = geofenceHeader;
     }
 
-    //</editor-fold>
+    public String getHiDpiMode() {
+        return hiDpiMode;
+    }
+
+    public void setHiDpiMode(String hiDpiMode) {
+        this.hiDpiMode = hiDpiMode;
+    }
+
+    public boolean isDisableTiling() {
+        return disableTiling;
+    }
+
+    public void setDisableTiling(boolean disableTiling) {
+        this.disableTiling = disableTiling;
+    }
+
+    public Integer getTilingGutter() {
+        return tilingGutter;
+    }
+
+    public void setTilingGutter(Integer tilingGutter) {
+        this.tilingGutter = tilingGutter;
+    }
+
+//</editor-fold>
 
     private JSONArray layersInApplications = new JSONArray();
   
@@ -528,6 +558,10 @@ public class GeoServiceActionBean extends LocalizableActionBean {
                     exception_type = ((WMSService) service).getException_type();
                     // default to false
                     skipDiscoverWFS = ((WMSService) service).getSkipDiscoverWFS() != null && ((WMSService) service).getSkipDiscoverWFS();
+
+                    hiDpiMode = service.getDetails().getOrDefault("hidpi.mode", new ClobElement("auto")).getValue();
+                    disableTiling = "true".equals(service.getDetails().getOrDefault("tiling.disable", new ClobElement("false")).getValue());
+                    tilingGutter = Integer.parseInt(service.getDetails().getOrDefault("tiling.gutter", new ClobElement("0")).getValue());
                     break;
             }
 
@@ -650,6 +684,10 @@ public class GeoServiceActionBean extends LocalizableActionBean {
             ((WMSService)service).setOverrideUrl(overrideUrl);
             ((WMSService) service).setException_type(exception_type);
             ((WMSService) service).setSkipDiscoverWFS(skipDiscoverWFS);
+
+            service.getDetails().put("hidpi.mode", new ClobElement(hiDpiMode));
+            service.getDetails().put("tiling.disable", new ClobElement(disableTiling + ""));
+            service.getDetails().put("tiling.gutter", new ClobElement(tilingGutter == null ? "0" : tilingGutter + ""));
         }
         EntityManager em = Stripersist.getEntityManager();
         // Invalidate the cache of the applications using this service. Options like username/password, useProxy, etc. might have changed, which
@@ -870,6 +908,9 @@ public class GeoServiceActionBean extends LocalizableActionBean {
                 service = WMSServiceHelper.loadFromUrl(url, params, status, em);
                 ((WMSService) service).setException_type(exception_type);
                 service.getDetails().put(GeoService.DETAIL_USE_PROXY, new ClobElement("" + useProxy));
+                service.getDetails().put("hidpi.mode", new ClobElement(hiDpiMode));
+                service.getDetails().put("tiling.disable", new ClobElement(disableTiling + ""));
+                service.getDetails().put("tiling.gutter", new ClobElement(tilingGutter == null ? "0" : tilingGutter + ""));
                 break;
             case ArcGISService.PROTOCOL:
                 params.put(ArcGISService.PARAM_ASSUME_VERSION, agsVersion);

--- a/src/main/webapp/WEB-INF/jsp/services/geoservice.jsp
+++ b/src/main/webapp/WEB-INF/jsp/services/geoservice.jsp
@@ -74,6 +74,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             Ext.fly('useUrlTr').setVisibilityMode(Ext.Element.DISPLAY).setVisible(protocol === "wms");
             Ext.fly('useWFSTr').setVisibilityMode(Ext.Element.DISPLAY).setVisible(protocol === "wms");
             Ext.fly('wmsExcTr').setVisibilityMode(Ext.Element.DISPLAY).setVisible(protocol === "wms");
+            Ext.fly('wmsHiDpi').setVisibilityMode(Ext.Element.DISPLAY).setVisible(protocol === "wms");
+            Ext.fly('tiling').setVisibilityMode(Ext.Element.DISPLAY).setVisible(protocol === "wms");
+            Ext.fly('tilingGutter').setVisibilityMode(Ext.Element.DISPLAY).setVisible(protocol === "wms");
             Ext.fly('serviceNameTr').setVisibilityMode(Ext.Element.DISPLAY).setVisible(protocol === "tiled" &&  tilingProtocol !== "WMTS");
             Ext.fly('tileSizeTr').setVisibilityMode(Ext.Element.DISPLAY).setVisible(protocol === "tiled" &&  tilingProtocol !== "WMTS");
             Ext.fly('resolutionsTr').setVisibilityMode(Ext.Element.DISPLAY).setVisible(protocol === "tiled" &&  tilingProtocol !== "WMTS");
@@ -218,14 +221,38 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         </tr>
         <tr>
             <td colspan="2">
-                <stripes:checkbox name="useIntersect"/> <fmt:message key="viewer_admin.geoservice.22" />
+                <label><stripes:checkbox name="useIntersect"/> <fmt:message key="viewer_admin.geoservice.22" /></label>
             </td>
         </tr>
         <tr id="useProxy">
             <td colspan="2">
-                <stripes:checkbox name="useProxy"/> <fmt:message key="viewer_admin.geoservice.23" />
+                <label><stripes:checkbox name="useProxy"/> <fmt:message key="viewer_admin.geoservice.23" /></label>
             </td>
-        </tr>        
+        </tr>
+        <tr id="wmsHiDpi">
+            <td>Weergave op hoge resolutie schermen</td>
+            <td>
+                <stripes:select name="hiDpiMode">
+                    <stripes:option value="auto">Automatisch bepalen op basis van URL (GeoServer, MapServer)</stripes:option>
+                    <stripes:option value="geoserver">Gebruik vendor-specific parameter voor GeoServer</stripes:option>
+                    <stripes:option value="mapserver">Gebruik vendor-specific parameter voor MapServer</stripes:option>
+                    <stripes:option value="disabled">Uitgeschakeld: geef lage resolutie weer</stripes:option>
+                </stripes:select>
+            </td>
+        </tr>
+        <tr id="tiling">
+            <td colspan="2"><label><stripes:checkbox name="disableTiling"/>Kaart niet getegeld ophalen</label><br>
+            <i>Let op! Als dit is aangevinkt wordt de kaart wordt mogelijk niet getoond op scherm met veel pixels omdat servers een limiet hebben op het formaat
+                van de afbeelding in een request. Daarom ook als dit aangevinkt is hoge resolutie weergave uitschakelen.</i></td>
+        </tr>
+        <tr id="tilingGutter">
+            <td>Gutter voor getegeld ophalen:</td>
+            <td>
+                <stripes:text name="tilingGutter" size="4"/> pixels<br>
+                Om rendering-artifacten op tegel-grenzen te voorkomen kan een extra 'gutter' worden opgehaald die voor weergave weer van
+                de tegel wordt afgesneden.
+            </td>
+        </tr>
         <tr>
             <td valign="top">
                 <h1><fmt:message key="viewer_admin.geoservice.24" />:</h1>                           

--- a/src/main/webapp/WEB-INF/jsp/services/layer.jsp
+++ b/src/main/webapp/WEB-INF/jsp/services/layer.jsp
@@ -28,7 +28,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <stripes:messages/>
             <stripes:form beanclass="nl.tailormap.viewer.admin.stripes.LayerActionBean">
 
-                <h1 id="headertext"><fmt:message key="viewer_admin.layer.1" /></h1>
+                <h1 id="headertext"><fmt:message key="viewer_admin.layer.1" /> - <c:out value="${actionBean.layer.name}"/></h1>
                 <stripes:hidden name="layer" value="${actionBean.layer.id}"/>
 
                 <table class="formtable">
@@ -129,6 +129,36 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                     </c:forEach>
                                 </tbody>
                             </table>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td colspan="2">
+                            <c:choose>
+                                <c:when test="${actionBean.layer.service.protocol == 'tiled'}">
+                                    <fieldset>
+                                        <legend>Weergave op hoge resolutie schermen </legend>
+                                        <label><stripes:radio name="details['hidpi.mode']" value="disabled"/>Toon lage resolutie</label><br>
+                                        <label><stripes:radio name="details['hidpi.mode']" value="showNextZoomLevel"/>Toon dieper zoomniveau weer met hoge pixeldichtheid (laag is DPI-onafhankelijk zoals een luchtfoto)</label><br>
+                                        <label><stripes:radio name="details['hidpi.mode']" value="substituteLayerShowNextZoomLevel"/>Vervang met andere laag en geef dieper zoomniveau weer met hoge pixeldichtheid (service geeft tiles van formaat zoals geadverteerd)</label><br>
+                                        <label><stripes:radio name="details['hidpi.mode']" value="substituteLayerTilePixelRatioOnly"/>Vervang met andere laag en geef hetzelfde zoomniveau weer met hoge pixeldichtheid (service geeft grotere tiles dan geadverteerd)</label><br>
+                                        Vervangende laag:
+                                        <stripes:select name="details['hidpi.substitute_layer']">
+                                            <stripes:option value=""/>
+                                            <c:forEach var="layer" items="${actionBean.allServiceLayers}">
+                                                <stripes:option value="${layer.name}">
+                                                    <b><c:out value="${layer.name}"/></b>
+                                                    <c:if test="${!empty layer.title}"> - <c:out value="${layer.title}"/>></c:if>
+                                                </stripes:option>
+                                            </c:forEach>
+                                        </stripes:select>
+                                    </fieldset>
+                                </c:when>
+                            </c:choose>
+                            <c:choose>
+                                <c:when test="${actionBean.layer.service.protocol == 'wms'}">
+                                    Voor WMS lagen kan op service-niveau de weergave op hoge resolutie-schermen worden ingesteld.
+                                </c:when>
+                            </c:choose>
                         </td>
                     </tr>
                     <c:if test="${not empty actionBean.applicationsUsedIn}">


### PR DESCRIPTION
HTM-48

For WMS services high resolution options are configured for all layers of the service:
- Autodetect based on URL
- GeoServer or MapServer vendor-specific parameters
- Disable high resolution

![Screenshot from 2022-06-16 17-04-28](https://user-images.githubusercontent.com/1926261/174130324-127876c0-e483-4f54-9314-d0f96c6f95cf.png)
![Screenshot from 2022-06-16 17-04-46](https://user-images.githubusercontent.com/1926261/174130408-79f863d0-d210-4004-bc55-a675ebeb697d.png)

Additionally tiled WMS requests can be disabled and the gutter can be configured for tiled WMS.

For tiled services, high resolution options are configured per layer. The options are somewhat technical and should be explained in documentation in the future. Since high resolution tiling is not standardized, there are three options beside showing low resolution.
![Screenshot from 2022-06-16 16-47-51](https://user-images.githubusercontent.com/1926261/174130458-be3114b2-90af-4bcf-9dc4-0b4f2b267ce9.png)

No i18n yet, but the admin interface should be replaced anyway...