### PR TITLE
Bump hibernate.version from 5.6.9.Final to 5.6.11.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,7 @@
     <apache.httpcomponents.version>4.5.13</apache.httpcomponents.version>
     <!--    <apache.commons-codec.version>1.15</apache.commons-codec.version>-->
     <activation.api.version>1.2.2</activation.api.version>
+    <hibernate.version>5.6.11.Final</hibernate.version>
     <jackson2.version>2.13.3</jackson2.version>
     <jackson2.databind.version>2.13.3</jackson2.databind.version>
     <test.junit-jupiter.version>5.9.0</test.junit-jupiter.version>


### PR DESCRIPTION
Override the Hibernate version as the upstream project does not do dependency updates...

Bump hibernate.version from 5.6.9.Final to 5.6.11.Final

related https://github.com/B3Partners/tailormap-persistence/pull/24