### PR TITLE
Override google closure compiler version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,11 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>com.google.javascript</groupId>
+        <artifactId>closure-compiler</artifactId>
+        <version>v20220104</version>
+      </dependency>
+      <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-core</artifactId>
         <version>${jackson2.version}</version>
@@ -365,7 +370,6 @@
         </exclusion>
       </exclusions>
     </dependency>
-
     <dependency>
       <groupId>org.tailormap-gbimaps</groupId>
       <artifactId>viewer-commons</artifactId>


### PR DESCRIPTION
Override google closure compiler from `org.tailormap-gbimaps:viewer-commons:jar:5.9.23` dependency