### PR TITLE
[HTM-528] Enable building multi-arch docker images, [HTM-532] fix missing HSQLDB dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ running Tailormap Admin
   ```shell
   mvn clean install
   ```
-  Note that on Windows and MacOS building the docker image is disabled by default, 
+  Note that on Windows, OpenBSD and MacOS building the docker image is disabled by default, 
   add the option `-Ddocker.skip=false` if you want to build the docker image
 - start a container using:
   ```shell

--- a/pom.xml
+++ b/pom.xml
@@ -482,7 +482,6 @@
     <dependency>
       <groupId>org.hsqldb</groupId>
       <artifactId>hsqldb</artifactId>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>nl.b3p.tailormap</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
     <dependency-check-maven.version>7.3.0</dependency-check-maven.version>
     <!--    <pmd.version>6.40.0</pmd.version>-->
     <!--    <errorProne.version>2.10.0</errorProne.version>-->
-    <errorProneFlags />
+    <errorProneFlags></errorProneFlags>
     <compiler.lint>deprecation,unchecked</compiler.lint>
     <fmt.action>format</fmt.action>
     <pom.fmt.action>sort</pom.fmt.action>
@@ -855,6 +855,12 @@
                   <TM_VERSION>${project.version}</TM_VERSION>
                 </args>
                 <noCache>true</noCache>
+                <buildx>
+                  <platforms>
+                    <platform>linux/amd64</platform>
+                    <platform>linux/arm64</platform>
+                  </platforms>
+                </buildx>
               </build>
             </image>
           </images>
@@ -1057,6 +1063,18 @@
       <activation>
         <os>
           <family>windows</family>
+        </os>
+      </activation>
+      <properties>
+        <docker.skip>true</docker.skip>
+      </properties>
+    </profile>
+    <profile>
+      <id>openbsd</id>
+      <activation>
+        <os>
+          <name>openbsd</name>
+          <family>unix</family>
         </os>
       </activation>
       <properties>

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -12,27 +12,24 @@ ENV TM_DATA_DIR=/opt/tailormap_data
 ENV CATALINA_OPTS="-DPG_PORT=$PG_PORT -DPG_HOST=$PG_HOST -DDB_NAME=$DB_NAME -DDB_USER=$DB_USER -DDB_PASS=$DB_PASS -DURL_SCHEME=$URL_SCHEME -DMAIL_FROM=$MAIL_FROM -DMAIL_HOST=$MAIL_HOST -DTM_DATA_DIR=$TM_DATA_DIR"
 ENV CATALINA_OUT=/dev/null
 
-ARG TM_VERSION="10.0-SNAPSHOT"
+ARG TM_VERSION="10.0.0-SNAPSHOT"
 ARG TZ="Europe/Amsterdam"
 ARG DEBIAN_FRONTEND="noninteractive"
 
 # copy webapps + jdni libs + config to tomcat directories
-# note we need ${project.basedir}/${project.build.directory} because we need an absolute path
-COPY ${project.build.directory}/admin.war /usr/local/tomcat/webapps/
-COPY ${project.build.directory}/tomcat-lib/*.jar /usr/local/tomcat/lib/
-COPY ${project.basedir}/src/main/docker/tomcat_conf/ /usr/local/tomcat/conf/
+COPY ./target/admin.war /usr/local/tomcat/webapps/admin.war
+COPY ./target/tomcat-lib/*.jar /usr/local/tomcat/lib/
+COPY ./src/main/docker/tomcat_conf/ /usr/local/tomcat/conf/
 
-RUN set -eux;mkdir -p $TM_DATA_DIR/ \
-    && TMPDIR=`mktemp -d` \
+RUN set -eux;ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone \
+    && mkdir -p $TM_DATA_DIR/ \
     && chmod -R 777 $TM_DATA_DIR/ \
     # cleanup localization and example apps
     && rm /usr/local/tomcat/lib/tomcat-i18n-*.jar \
     && rm -rf /usr/local/tomcat/webapps.dist/ \
-    && rm -rf $TMPDIR \
-    && apt update && apt upgrade -y && apt autoremove -y && apt autoclean && apt clean && rm -rf /tmp/* && rm -rf /var/tmp/* \
-    && rm -rf /var/lib/apt/lists/* \
-    && chown -R www-data:www-data /usr/local/tomcat/webapps \
-    && ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+    && chown -R www-data:www-data /usr/local/tomcat/webapps
+# currently fails on arm64 with "debconf: delaying package configuration, since apt-utils is not installed" exit code: 100
+#    && apt update && apt upgrade -y && apt autoremove -y && apt autoclean && apt clean && rm -rf /tmp/* && rm -rf /var/tmp/* && rm -rf /var/lib/apt/lists/* \
 
 USER www-data:www-data
 


### PR DESCRIPTION
for now stick to `linux/amd64` and `linux/arm64 (linux/arm64/v8)`

resolve HTM-528, HTM-532