### PR TITLE
Update OWASP dependency-check config after analysing reports

### DIFF
--- a/.github/workflows/owasp-dependency-check.yml
+++ b/.github/workflows/owasp-dependency-check.yml
@@ -37,13 +37,9 @@ jobs:
 
       - name: OWASP Dependency Check
         continue-on-error: true
-        run: mvn -U install -DskipTests -DskipITs -Ddocker.skip=true org.owasp:dependency-check-maven:check -fae -B -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN -DfailBuildOnCVSS=5
+        run: mvn -U package -Dmaven.test.skip=true -Ddocker.skip=true org.owasp:dependency-check-maven:check -fae -B -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN -DfailBuildOnCVSS=5
 
       - name: Upload result to GitHub Code Scanning
         uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: target/dependency-check-report.sarif
-
-      - name: Cleanup snapshots
-        run: |
-          find ~/.m2/repository -name "*SNAPSHOT*" -type d | xargs rm -rf {}

--- a/.github/workflows/ubuntu-maven.yml
+++ b/.github/workflows/ubuntu-maven.yml
@@ -32,7 +32,7 @@ jobs:
       postgres:
         # docker run -h tailormap-db --name tailormap-db -it --rm -d \
         #  -e POSTGRES_USER=${DB_USER} -e POSTGRES_DB=${DB_NAME} -e POSTGRES_PASSWORD=${DB_PASS} -p 5432:5432 postgres:14-alpine
-        image: postgres:14-alpine
+        image: postgres:15-alpine
         env:
           POSTGRES_USER: ${{ env.DB_USER }}
           POSTGRES_PASSWORD: ${{ env.DB_PASS }}

--- a/build/qa/owasp-suppression.xml
+++ b/build/qa/owasp-suppression.xml
@@ -1,4 +1,34 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-
+    <suppress>
+        <notes><![CDATA[
+   file name: geotools-commons-5.9.24.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.tailormap\-gbimaps/geotools\-commons@.*$</packageUrl>
+        <cpe>cpe:/a:geotools:geotools</cpe>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+   file name: gt-coverage-28-RC.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.geotools/gt\-coverage@.*$</packageUrl>
+        <cpe>cpe:/a:image_processing_software:image_processing_software</cpe>
+        <cpe>cpe:/a:processing:processing</cpe>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+   file name: spring-security-crypto-5.7.5.jar
+   We don't use Encryptors#queryableText(CharSequence, CharSequence)
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework\.security/spring\-security\-crypto@.*$</packageUrl>
+        <vulnerabilityName>CVE-2020-5408</vulnerabilityName>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+   file name: guava-27.0-jre.jar transitive dependency from it.geosolutions.jaiext.stats:jt-stats / geotools wms
+   The vulnerable code is not used in the application
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.google\.guava/guava@.*$</packageUrl>
+        <cve>CVE-2020-8908</cve>
+    </suppress>
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -122,11 +122,6 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>com.google.javascript</groupId>
-        <artifactId>closure-compiler</artifactId>
-        <version>v20221102</version>
-      </dependency>
-      <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-core</artifactId>
         <version>${jackson2.version}</version>
@@ -383,6 +378,10 @@
         <exclusion>
           <groupId>org.tailormap-gbimaps</groupId>
           <artifactId>viewer-config-persistence</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.javascript</groupId>
+          <artifactId>closure-compiler</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,8 @@
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <spring-security.version>5.7.5</spring-security.version>
-    <tailormap.version>5.9.24</tailormap.version>
+    <tailormap-gbimaps.version>5.9.24</tailormap-gbimaps.version>
+    <tailormap-persistence.version>10.1-SNAPSHOT</tailormap-persistence.version>
     <geotools.version>28-RC</geotools.version>
     <jts.version>1.19.0</jts.version>
     <apache.poi.version>5.2.3</apache.poi.version>
@@ -275,7 +276,7 @@
       <dependency>
         <groupId>org.tailormap-gbimaps</groupId>
         <artifactId>tailormap-gbimaps</artifactId>
-        <version>${tailormap.version}</version>
+        <version>${tailormap-gbimaps.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -290,7 +291,7 @@
     <dependency>
       <groupId>nl.b3p.tailormap</groupId>
       <artifactId>tailormap-persistence</artifactId>
-      <version>10.1-SNAPSHOT</version>
+      <version>${tailormap-persistence.version}</version>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>
@@ -368,6 +369,11 @@
           <groupId>javax.servlet.jsp</groupId>
           <artifactId>jsp-api</artifactId>
         </exclusion>
+        <exclusion>
+          <!-- 1.2.5 sleept xalan mee, maar dat willen we niet -->
+          <groupId>xalan</groupId>
+          <artifactId>xalan</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -405,6 +411,10 @@
         <exclusion>
           <groupId>org.geotools</groupId>
           <artifactId>gt-epsg-wkt</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>xalan</groupId>
+          <artifactId>xalan</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -485,7 +495,7 @@
     <dependency>
       <groupId>nl.b3p.tailormap</groupId>
       <artifactId>tailormap-persistence</artifactId>
-      <version>10.0</version>
+      <version>${tailormap-persistence.version}</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
@@ -494,6 +504,12 @@
       <artifactId>viewer-helpers</artifactId>
       <type>test-jar</type>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>xalan</groupId>
+          <artifactId>xalan</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>

--- a/src/main/java/nl/tailormap/viewer/admin/stripes/ApplicationSettingsActionBean.java
+++ b/src/main/java/nl/tailormap/viewer/admin/stripes/ApplicationSettingsActionBean.java
@@ -474,7 +474,7 @@ public class ApplicationSettingsActionBean extends ApplicationActionBean {
         // When the selected application is a mashup, don't use the copy routine, but make another mashup of it. This prevents some detached entity exceptions.
         if(application.isMashup()){
             copy = ApplicationHelper.createMashup(application, name, em, false);
-            SelectedContentCache.setApplicationCacheDirty(copy, Boolean.TRUE, true, em);
+//            SelectedContentCache.setApplicationCacheDirty(copy, Boolean.TRUE, true, em);
         }else{
             bindAppProperties();
 
@@ -485,7 +485,7 @@ public class ApplicationSettingsActionBean extends ApplicationActionBean {
             em.persist(copy);
             em.persist(copy);
             em.flush();
-            SelectedContentCache.setApplicationCacheDirty(copy, Boolean.TRUE, false, em);
+//            SelectedContentCache.setApplicationCacheDirty(copy, Boolean.TRUE, false, em);
         }
         em.getTransaction().commit();
 
@@ -532,7 +532,7 @@ public class ApplicationSettingsActionBean extends ApplicationActionBean {
             if(mashupMustPointToPublishedVersion){
                 for (Application mashup: ApplicationHelper.getMashups(oldPublished, em)) {
                     mashup.setRoot(application.getRoot());//nog iets doen met veranderde layerids uit cofniguratie
-                    SelectedContentCache.setApplicationCacheDirty(mashup,true, false,em);
+//                    SelectedContentCache.setApplicationCacheDirty(mashup,true, false,em);
                     ApplicationHelper.transferMashupLevels(mashup, oldPublished,em);
                     ApplicationHelper.transferMashupComponents(mashup, application);
                     em.persist(mashup);

--- a/src/main/java/nl/tailormap/viewer/admin/stripes/ApplicationStartMapActionBean.java
+++ b/src/main/java/nl/tailormap/viewer/admin/stripes/ApplicationStartMapActionBean.java
@@ -139,7 +139,7 @@ public class ApplicationStartMapActionBean extends ApplicationActionBean {
         }
         
         walkAppTreeForSave(rootlevel,em,false);
-        SelectedContentCache.setApplicationCacheDirty(application, true,false,true,em);
+//        SelectedContentCache.setApplicationCacheDirty(application, true,false,true,em);
         em.getTransaction().commit();
     }
     

--- a/src/main/java/nl/tailormap/viewer/admin/stripes/ApplicationTreeActionBean.java
+++ b/src/main/java/nl/tailormap/viewer/admin/stripes/ApplicationTreeActionBean.java
@@ -354,7 +354,7 @@ public class ApplicationTreeActionBean extends ApplicationActionBean {
 
         em.persist(l);
         em.persist(parent);
-        SelectedContentCache.setApplicationCacheDirty(application, true,false,em);
+//        SelectedContentCache.setApplicationCacheDirty(application, true,false,em);
         application.authorizationsModified();
         em.getTransaction().commit();
 
@@ -379,7 +379,7 @@ public class ApplicationTreeActionBean extends ApplicationActionBean {
         try{
             EntityManager em = Stripersist.getEntityManager();
             moveLevel(levelId, targetLevelId, em);
-            SelectedContentCache.setApplicationCacheDirty(application, true, false, em);
+//            SelectedContentCache.setApplicationCacheDirty(application, true, false, em);
             application.authorizationsModified();
             em.getTransaction().commit(); 
            j.put("success", true);

--- a/src/main/java/nl/tailormap/viewer/admin/stripes/ApplicationTreeLayerActionBean.java
+++ b/src/main/java/nl/tailormap/viewer/admin/stripes/ApplicationTreeLayerActionBean.java
@@ -327,7 +327,7 @@ public class ApplicationTreeLayerActionBean extends ApplicationActionBean {
         application.authorizationsModified();
 
         displayName = applicationLayer.getDisplayName(em);
-        SelectedContentCache.setApplicationCacheDirty(application, true, false,em);
+//        SelectedContentCache.setApplicationCacheDirty(application, true, false,em);
         
         em.getTransaction().commit();
 

--- a/src/main/java/nl/tailormap/viewer/admin/stripes/ApplicationTreeLevelActionBean.java
+++ b/src/main/java/nl/tailormap/viewer/admin/stripes/ApplicationTreeLevelActionBean.java
@@ -108,7 +108,7 @@ public class ApplicationTreeLevelActionBean extends ApplicationActionBean {
         }
         
         application.authorizationsModified();        
-        SelectedContentCache.setApplicationCacheDirty(application, true, false,em);
+//        SelectedContentCache.setApplicationCacheDirty(application, true, false,em);
         em.getTransaction().commit();
         
         return new ForwardResolution(JSP);
@@ -148,7 +148,7 @@ public class ApplicationTreeLevelActionBean extends ApplicationActionBean {
             try {
                 EntityManager em = Stripersist.getEntityManager();
                 em.persist(level);
-                SelectedContentCache.setApplicationCacheDirty(application, true, false, em);
+//                SelectedContentCache.setApplicationCacheDirty(application, true, false, em);
                 em.getTransaction().commit();
                 json.put("name", level.getName());
                 json.put("success", Boolean.TRUE);
@@ -212,7 +212,7 @@ public class ApplicationTreeLevelActionBean extends ApplicationActionBean {
                 
                 em.remove(level);
                 application.authorizationsModified();
-                SelectedContentCache.setApplicationCacheDirty(application, true, false, em);
+//                SelectedContentCache.setApplicationCacheDirty(application, true, false, em);
                 em.getTransaction().commit();
 
             } catch(Exception e) {
@@ -268,7 +268,7 @@ public class ApplicationTreeLevelActionBean extends ApplicationActionBean {
         for (Application app : mashups) {
 
             app.authorizationsModified();
-            SelectedContentCache.setApplicationCacheDirty(app, true, false, em);
+//            SelectedContentCache.setApplicationCacheDirty(app, true, false, em);
         }
         em.getTransaction().commit();
         

--- a/src/main/java/nl/tailormap/viewer/admin/stripes/GeoServiceActionBean.java
+++ b/src/main/java/nl/tailormap/viewer/admin/stripes/GeoServiceActionBean.java
@@ -691,9 +691,9 @@ public class GeoServiceActionBean extends LocalizableActionBean {
         // Invalidate the cache of the applications using this service. Options like username/password, useProxy, etc. might have changed, which
         // affect the selectedContent
         List<Application> apps = findApplications();
-        for (Application application : apps) {
-            SelectedContentCache.setApplicationCacheDirty(application, true, false, em);
-        }
+//        for (Application application : apps) {
+//            SelectedContentCache.setApplicationCacheDirty(application, true, false, em);
+//        }
         service.getDetails().put(GeoService.DETAIL_USE_INTERSECT, new ClobElement(""+useIntersect));
         service.getDetails().put(GeoService.DETAIL_USE_PROXY, new ClobElement(""+useProxy));
         
@@ -825,9 +825,9 @@ public class GeoServiceActionBean extends LocalizableActionBean {
         log.info("Missing layers: " + byStatus.get(UpdateResult.Status.MISSING));
 
         List<Application> apps = findApplications();
-        for (Application application : apps) {
-            SelectedContentCache.setApplicationCacheDirty(application, true, false,em);
-        }
+//        for (Application application : apps) {
+//            SelectedContentCache.setApplicationCacheDirty(application, true, false,em);
+//        }
 
         em.getTransaction().commit();
 

--- a/src/main/java/nl/tailormap/viewer/admin/stripes/LayerActionBean.java
+++ b/src/main/java/nl/tailormap/viewer/admin/stripes/LayerActionBean.java
@@ -301,9 +301,9 @@ public class LayerActionBean extends LocalizableActionBean {
         em.persist(layer);
         layer.getService().authorizationsModified();
         List<Application> apps = findApplications(layer);
-        for (Application application : apps) {
-            SelectedContentCache.setApplicationCacheDirty(application, true, false, em);
-        }
+//        for (Application application : apps) {
+//            SelectedContentCache.setApplicationCacheDirty(application, true, false, em);
+//        }
         em.getTransaction().commit();
         getContext().getMessages().add(new SimpleMessage(getBundle().getString("viewer_admin.layeractionbean.layersaved")));
 

--- a/src/test/java/nl/tailormap/viewer/admin/stripes/ApplicationStartMapActionBeanTest.java
+++ b/src/test/java/nl/tailormap/viewer/admin/stripes/ApplicationStartMapActionBeanTest.java
@@ -386,11 +386,11 @@ public class ApplicationStartMapActionBeanTest extends TestUtil {
     @Test
     public void testSelectedContentCreationWithDeletedLevel() {
         testRemoveStartLevelWithParent();
-        SelectedContentCache scc = new SelectedContentCache();
-        JSONObject selectedContent = scc.createSelectedContent(application, false, false, false, entityManager);
-        JSONObject levels = selectedContent.getJSONObject("levels");
-        JSONObject level5 = levels.getJSONObject("5");
-        assertTrue(level5.optBoolean("removed", false), "Should have removed parameter in level in selectedContent");
+//        SelectedContentCache scc = new SelectedContentCache();
+//        JSONObject selectedContent = scc.createSelectedContent(application, false, false, false, entityManager);
+//        JSONObject levels = selectedContent.getJSONObject("levels");
+//        JSONObject level5 = levels.getJSONObject("5");
+//        assertTrue(level5.optBoolean("removed", false), "Should have removed parameter in level in selectedContent");
     }
 
     @Test
@@ -417,17 +417,17 @@ public class ApplicationStartMapActionBeanTest extends TestUtil {
         entityManager.getTransaction().begin();
 
 
-        SelectedContentCache scc = new SelectedContentCache();
-        JSONObject selectedContent = scc.createSelectedContent(application, false, false, false, entityManager);
-        JSONObject levels = selectedContent.getJSONObject("levels");
+//        SelectedContentCache scc = new SelectedContentCache();
+//        JSONObject selectedContent = scc.createSelectedContent(application, false, false, false, entityManager);
+//        JSONObject levels = selectedContent.getJSONObject("levels");
 
-        JSONObject level4 = levels.getJSONObject("4");
-        assertTrue(level4.optBoolean("removed", false), "Should have removed parameter in level3 in selectedContent");
+//        JSONObject level4 = levels.getJSONObject("4");
+//        assertTrue(level4.optBoolean("removed", false), "Should have removed parameter in level3 in selectedContent");
 
-        JSONObject level5 = levels.getJSONObject("5");
-        assertTrue(level5.optBoolean("removed", false), "Should have removed parameter in level4 in selectedContent");
+//        JSONObject level5 = levels.getJSONObject("5");
+//        assertTrue(level5.optBoolean("removed", false), "Should have removed parameter in level4 in selectedContent");
 
-        JSONObject level6 = levels.getJSONObject("5");
-        assertTrue(level6.optBoolean("removed", false), "Should have removed parameter in level5 in selectedContent");
+//        JSONObject level6 = levels.getJSONObject("5");
+//        assertTrue(level6.optBoolean("removed", false), "Should have removed parameter in level5 in selectedContent");
     }
 }

--- a/src/test/java/nl/tailormap/viewer/admin/stripes/ApplicationTreeActionBeanTest.java
+++ b/src/test/java/nl/tailormap/viewer/admin/stripes/ApplicationTreeActionBeanTest.java
@@ -121,12 +121,12 @@ public class ApplicationTreeActionBeanTest extends TestUtil {
         entityManager.getTransaction().commit();
         entityManager.getTransaction().begin();
 
-        SelectedContentCache scc = new SelectedContentCache();
-        Application application = entityManager.find(Application.class, applicationId);
+//        SelectedContentCache scc = new SelectedContentCache();
+//        Application application = entityManager.find(Application.class, applicationId);
 
-        JSONObject json = scc.createSelectedContent(application, false, false, false, entityManager);
-        JSONArray selectedContent = json.getJSONArray("selectedContent");
-        assertEquals(2, selectedContent.length());
+//        JSONObject json = scc.createSelectedContent(application, false, false, false, entityManager);
+//        JSONArray selectedContent = json.getJSONArray("selectedContent");
+//        assertEquals(2, selectedContent.length());
     }
 
 }


### PR DESCRIPTION
- exclude/remove Xalan and disable the SelectedContentCache, it's not used in the API and it requires xalan
- fix `tailormap-gbimaps.version` and `tailormap-persistence.version`
- Remove `com.google.javascript:closure-compiler` dependency, which was used in legacy ComponentActionBean

this relieves us of notifications about:
- CVE-2022-34169
- CVE-2020-5408
- CVE-2020-8908
- CVE-2018-1000840, CVE-2005-0406 
- CVE-2022-24818
- CVE-2022-3171