### PR TITLE
Add English back to locales

### DIFF
--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -135,7 +135,7 @@
             <!-- Note that the option to specify the encoding using nl_NL:UTF-8
                  is not required because we have a separate filter for that:
                  SetCharacterEncodingFilter -->
-            <param-value>nl</param-value>
+            <param-value>nl,en</param-value>
         </init-param>
         <init-param>
             <param-name>LocalizationBundleFactory.ErrorMessageBundle</param-name>


### PR DESCRIPTION
English was removed 4 years ago, not sure why. Picks language based on browser language, so a Dutch user may see an English admin if he does not set his browser language to Dutch (quite common). In the future a new admin could have an option to override the browser language.

Note that the Angular configuration bundle is loaded according to the language as well.