### PR TITLE
this should fix the release-deploy of tag and latest using buildx in 1 run

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
     <dependency-check-maven.version>7.4.1</dependency-check-maven.version>
     <!--    <pmd.version>6.50.0</pmd.version>-->
     <!--    <errorProne.version>2.16</errorProne.version>-->
-    <errorProneFlags />
+    <errorProneFlags></errorProneFlags>
     <compiler.lint>deprecation,unchecked</compiler.lint>
     <fmt.action>format</fmt.action>
     <pom.fmt.action>sort</pom.fmt.action>
@@ -1125,7 +1125,6 @@
               </images>
             </configuration>
             <executions>
-              </execution>
               <execution>
                 <id>docker-push</id>
                 <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -1084,26 +1084,50 @@
             <artifactId>docker-maven-plugin</artifactId>
             <configuration>
               <verbose>true</verbose>
+              <imagePullPolicy>Always</imagePullPolicy>
               <images>
                 <image>
                   <name>${docker.deploy.repo}/b3partners/%a:%l</name>
+                  <build>
+                    <!-- default location -->
+                    <dockerFile>${project.basedir}/src/main/docker/Dockerfile</dockerFile>
+                    <contextDir>${project.basedir}</contextDir>
+                    <args>
+                      <TM_VERSION>${project.version}</TM_VERSION>
+                    </args>
+                    <noCache>true</noCache>
+                    <buildx>
+                      <platforms>
+                        <platform>linux/amd64</platform>
+                        <platform>linux/arm64</platform>
+                      </platforms>
+                    </buildx>
+                  </build>
+                </image>
+                <image>
+                  <name>${docker.deploy.repo}/b3partners/%a:latest</name>
+                  <build>
+                    <!-- default location -->
+                    <dockerFile>${project.basedir}/src/main/docker/Dockerfile</dockerFile>
+                    <contextDir>${project.basedir}</contextDir>
+                    <args>
+                      <TM_VERSION>${project.version}</TM_VERSION>
+                    </args>
+                    <noCache>true</noCache>
+                    <buildx>
+                      <platforms>
+                        <platform>linux/amd64</platform>
+                        <platform>linux/arm64</platform>
+                      </platforms>
+                    </buildx>
+                  </build>
                 </image>
               </images>
             </configuration>
             <executions>
-              <execution>
-                <id>docker-tag</id>
-                <goals>
-                  <goal>tag</goal>
-                </goals>
-                <phase>verify</phase>
-                <configuration>
-                  <tagName>latest</tagName>
-                  <repo>${docker.deploy.repo}/b3partners</repo>
-                </configuration>
               </execution>
               <execution>
-                <id>docker-push-latest</id>
+                <id>docker-push</id>
                 <goals>
                   <goal>push</goal>
                 </goals>
@@ -1111,6 +1135,9 @@
                 <configuration>
                   <verbose>true</verbose>
                   <images>
+                    <image>
+                      <name>${docker.deploy.repo}/b3partners/%a:%l</name>
+                    </image>
                     <image>
                       <name>${docker.deploy.repo}/b3partners/%a:latest</name>
                     </image>


### PR DESCRIPTION
`buildx` has subtle differences for tagging and pushing